### PR TITLE
Payment method styling improvements

### DIFF
--- a/pinax_theme_bootstrap/static/pinax/css/theme.css
+++ b/pinax_theme_bootstrap/static/pinax/css/theme.css
@@ -14,3 +14,19 @@ footer {
 p.login-signup {
     margin-top: 20px;
 }
+
+
+// ------------------------  Stripe
+
+#payment-exp-month, #payment-exp-cvc {
+    padding: 6px;
+    min-width: 40px;
+}
+
+#payment-exp-year {
+    margin-left: -15px;
+}
+
+.for-cvc {
+    max-width: 50px;
+}

--- a/pinax_theme_bootstrap/templates/pinax/stripe/paymentmethod_create.html
+++ b/pinax_theme_bootstrap/templates/pinax/stripe/paymentmethod_create.html
@@ -28,16 +28,16 @@
                     </div>
                   </div>
                   <div class="form-group">
-                    <label for="expMonth" class="col-sm-2 control-label">Expiration</label>
-                    <div class="col-sm-1">
-                        <input type="text" size="2" class="form-control" data-stripe="exp-month"/>
+                    <label for="expMonth" class="col-sm-2 col-xs-3 control-label">Expiration</label>
+                    <div class="col-sm-1 col-xs-2">
+                        <input type="text" size="2" class="form-control" id="payment-exp-month" data-stripe="exp-month" placeholder="MM"/>
                     </div>
-                    <div class="col-sm-2">
-                        <input type="text" size="4" class="form-control" data-stripe="exp-year"/>
+                    <div class="col-sm-2 col-xs-3">
+                        <input type="text" size="4" class="form-control" id="payment-exp-year" data-stripe="exp-year" placeholder="YYYY"/>
                     </div>
-                    <label for="cvc" class="col-sm-2 control-label">CVC</label>
-                    <div class="col-sm-2">
-                      <input type="text" size="4" class="form-control" data-stripe="cvc" />
+                    <label for="cvc" class="col-xs-2 control-label for-cvc">CVC</label>
+                    <div class="col-sm-2 col-xs-2">
+                      <input type="text" size="4" class="form-control" id="payment-exp-cvc" data-stripe="cvc" placeholder="000" />
                     </div>
                   </div>
             </div>


### PR DESCRIPTION
Improved styling for CC information for `paymentmethod_create`
template. Can now both integers for month field on smaller screens.
Forms also look much improved on smaller screen sizes, retaining the
same structure from the larger screen sizes.
